### PR TITLE
[#9] Order 서비스 및 컨트롤러 계층 추가 

### DIFF
--- a/src/main/java/com/example/minimart/order/controller/OrderController.java
+++ b/src/main/java/com/example/minimart/order/controller/OrderController.java
@@ -3,12 +3,16 @@ package com.example.minimart.order.controller;
 import com.example.minimart.order.controller.dto.request.CreateOrderRequest;
 import com.example.minimart.order.repository.entity.Order;
 import com.example.minimart.order.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RequestMapping("/api/orders")
 @RestController
+@Tag(name = "Order API", description = "주문 관련 API")
 public class OrderController {
 
     private final OrderService orderService;
@@ -18,16 +22,23 @@ public class OrderController {
     }
 
     @GetMapping("/{id}")
-    public Order getOrder(@PathVariable Long id) {
+    @Operation(summary = "주문 조회", description = "주문 ID를 사용하여 특정 주문을 조회합니다.")
+    public Order getOrder(
+        @PathVariable
+        @Parameter(description = "주문 ID", example = "1", required = true)
+        Long id
+    ) {
         return orderService.getOrder(id);
     }
 
     @PostMapping
+    @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다.")
     public void createOrder(@RequestBody CreateOrderRequest request) {
         orderService.createOrder(request);
     }
 
     @GetMapping
+    @Operation(summary = "주문 목록 조회", description = "전체 주문 목록을 조회합니다.")
     public List<Order> listOrders() {
         return orderService.listOrders();
     }

--- a/src/main/java/com/example/minimart/order/controller/OrderController.java
+++ b/src/main/java/com/example/minimart/order/controller/OrderController.java
@@ -1,0 +1,35 @@
+package com.example.minimart.order.controller;
+
+import com.example.minimart.order.controller.dto.request.CreateOrderRequest;
+import com.example.minimart.order.repository.entity.Order;
+import com.example.minimart.order.service.OrderService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/api/orders")
+@RestController
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @GetMapping("/{id}")
+    public Order getOrder(@PathVariable Long id) {
+        return orderService.getOrder(id);
+    }
+
+    @PostMapping
+    public void createOrder(@RequestBody CreateOrderRequest request) {
+        orderService.createOrder(request);
+    }
+
+    @GetMapping
+    public List<Order> listOrders() {
+        return orderService.listOrders();
+    }
+
+}

--- a/src/main/java/com/example/minimart/order/controller/dto/request/CreateOrderItemRequest.java
+++ b/src/main/java/com/example/minimart/order/controller/dto/request/CreateOrderItemRequest.java
@@ -1,0 +1,50 @@
+package com.example.minimart.order.controller.dto.request;
+
+import java.math.BigDecimal;
+
+public class CreateOrderItemRequest {
+
+    private Long productId;
+    private String productName;
+    private Integer quantity;
+    private BigDecimal price;
+    private String option;
+
+    protected CreateOrderItemRequest() {
+    }
+
+    public CreateOrderItemRequest(
+        Long productId,
+        String productName,
+        Integer quantity,
+        BigDecimal price,
+        String option
+    ) {
+        this.productId = productId;
+        this.productName = productName;
+        this.quantity = quantity;
+        this.price = price;
+        this.option = option;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getOption() {
+        return option;
+    }
+
+}

--- a/src/main/java/com/example/minimart/order/controller/dto/request/CreateOrderItemRequest.java
+++ b/src/main/java/com/example/minimart/order/controller/dto/request/CreateOrderItemRequest.java
@@ -1,13 +1,25 @@
 package com.example.minimart.order.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 
+@Schema(description = "주문 항목 요청")
 public class CreateOrderItemRequest {
 
+    @Schema(description = "상품 ID", example = "101", required = true)
     private Long productId;
+
+    @Schema(description = "상품 이름", example = "Product A", required = true)
     private String productName;
+
+    @Schema(description = "주문 수량", example = "2", required = true)
     private Integer quantity;
+
+    @Schema(description = "상품 단가", example = "20.00", required = true)
     private BigDecimal price;
+
+    @Schema(description = "옵션 정보", example = "Color: Red")
     private String option;
 
     protected CreateOrderItemRequest() {

--- a/src/main/java/com/example/minimart/order/controller/dto/request/CreateOrderRequest.java
+++ b/src/main/java/com/example/minimart/order/controller/dto/request/CreateOrderRequest.java
@@ -1,0 +1,39 @@
+package com.example.minimart.order.controller.dto.request;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class CreateOrderRequest {
+
+    private Long customerId;
+
+    private BigDecimal totalPrice;
+
+    private List<CreateOrderItemRequest> items;
+
+    protected CreateOrderRequest() {
+    }
+
+    public CreateOrderRequest(
+        Long customerId,
+        BigDecimal totalPrice,
+        List<CreateOrderItemRequest> items
+    ) {
+        this.customerId = customerId;
+        this.totalPrice = totalPrice;
+        this.items = items;
+    }
+
+    public Long getCustomerId() {
+        return customerId;
+    }
+
+    public BigDecimal getTotalPrice() {
+        return totalPrice;
+    }
+
+    public List<CreateOrderItemRequest> getItems() {
+        return items;
+    }
+
+}

--- a/src/main/java/com/example/minimart/order/controller/dto/request/CreateOrderRequest.java
+++ b/src/main/java/com/example/minimart/order/controller/dto/request/CreateOrderRequest.java
@@ -1,14 +1,20 @@
 package com.example.minimart.order.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
 import java.util.List;
 
+@Schema(description = "주문 생성 요청")
 public class CreateOrderRequest {
 
+    @Schema(description = "고객 ID", example = "1", required = true)
     private Long customerId;
 
+    @Schema(description = "주문 총 금액", example = "100.00", required = true)
     private BigDecimal totalPrice;
 
+    @Schema(description = "주문 항목 리스트", required = true)
     private List<CreateOrderItemRequest> items;
 
     protected CreateOrderRequest() {

--- a/src/main/java/com/example/minimart/order/repository/entity/Order.java
+++ b/src/main/java/com/example/minimart/order/repository/entity/Order.java
@@ -41,13 +41,11 @@ public class Order {
     public Order(
         Long customerId,
         BigDecimal totalPrice,
-        OrderStatus status,
-        List<OrderItem> items
+        OrderStatus status
     ) {
         validateCustomerId(customerId);
         validateTotalPrice(totalPrice);
         validateOrderStatus(status);
-        validateOrderItems(items);
 
         this.customerId = customerId;
         this.totalPrice = totalPrice;

--- a/src/main/java/com/example/minimart/order/repository/entity/OrderItem.java
+++ b/src/main/java/com/example/minimart/order/repository/entity/OrderItem.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import org.springframework.util.Assert;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
@@ -35,6 +36,12 @@ public class OrderItem {
     @Column(nullable = false, precision = 19, scale = 2)
     private BigDecimal totalPrice;
 
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
     @Column(nullable = false)
     private boolean deleted = false;
 
@@ -62,6 +69,17 @@ public class OrderItem {
         this.unitPrice = unitPrice;
         this.quantity = quantity;
         this.totalPrice = calculateTotalPrice();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
     }
 
     public BigDecimal calculateTotalPrice() {

--- a/src/main/java/com/example/minimart/order/repository/entity/OrderItem.java
+++ b/src/main/java/com/example/minimart/order/repository/entity/OrderItem.java
@@ -42,17 +42,20 @@ public class OrderItem {
     }
 
     public OrderItem(
+        Long orderId,
         Long productId,
         String productName,
         String productOption,
         BigDecimal unitPrice,
         int quantity
     ) {
+        validateOrderId(productId);
         validateProductId(productId);
         validateProductName(productName);
         validateUnitPrice(unitPrice);
         validateQuantity(quantity);
 
+        this.orderId = orderId;
         this.productId = productId;
         this.productName = productName;
         this.productOption = productOption;
@@ -69,6 +72,11 @@ public class OrderItem {
         Assert.notNull(orderId, "Order ID는 null일 수 없습니다.");
 
         this.orderId = orderId;
+    }
+
+    private void validateOrderId(Long orderId) {
+        Assert.notNull(orderId, "주문 ID는 null일 수 없습니다.");
+        Assert.isTrue(orderId > 0, "주문 ID는 0보다 커야 합니다.");
     }
 
     private void validateProductId(Long productId) {

--- a/src/main/java/com/example/minimart/order/service/OrderService.java
+++ b/src/main/java/com/example/minimart/order/service/OrderService.java
@@ -1,0 +1,59 @@
+package com.example.minimart.order.service;
+
+import com.example.minimart.order.controller.dto.request.CreateOrderRequest;
+import com.example.minimart.order.repository.OrderItemJpaRepository;
+import com.example.minimart.order.repository.OrderJpaRepository;
+import com.example.minimart.order.repository.entity.Order;
+import com.example.minimart.order.repository.entity.OrderItem;
+import com.example.minimart.order.repository.entity.OrderStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@Service
+public class OrderService {
+
+    private final OrderJpaRepository orderJpaRepository;
+    private final OrderItemJpaRepository orderItemJpaRepository;
+
+    public OrderService(OrderJpaRepository orderJpaRepository, OrderItemJpaRepository orderItemJpaRepository) {
+        this.orderJpaRepository = orderJpaRepository;
+        this.orderItemJpaRepository = orderItemJpaRepository;
+    }
+
+    public Order getOrder(Long id) {
+        return orderJpaRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다. 주문 ID: " + id));
+    }
+
+    public void createOrder(CreateOrderRequest request) {
+        Order order = new Order(
+            request.getCustomerId(),
+            request.getTotalPrice(),
+            OrderStatus.PENDING
+        );
+
+        Order savedOrder = orderJpaRepository.save(order);
+        Long orderId = savedOrder.getId();
+
+        List<OrderItem> orderItems = request.getItems().stream()
+            .map(item -> new OrderItem(
+                orderId,
+                item.getProductId(),
+                item.getProductName(),
+                item.getOption(),
+                item.getPrice(),
+                item.getQuantity()
+            ))
+            .toList();
+
+        orderItemJpaRepository.saveAll(orderItems);
+    }
+
+    public List<Order> listOrders() {
+        return orderJpaRepository.findAll();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        show_sql: true

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,0 +1,30 @@
+-- orders 테이블
+CREATE TABLE orders (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    customer_id BIGINT NOT NULL,
+    total_price DECIMAL(19, 2) NOT NULL,
+    status ENUM('PENDING', 'CONFIRMED', 'SHIPPED', 'DELIVERED', 'CANCELLED') NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    INDEX idx_orders_customer_id (customer_id),
+    INDEX idx_orders_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- order_items 테이블
+CREATE TABLE order_items (
+     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+     order_id BIGINT NOT NULL,
+     product_id BIGINT NOT NULL,
+     product_name VARCHAR(255) NOT NULL,
+     product_option VARCHAR(255),
+     unit_price DECIMAL(19, 2) NOT NULL,
+     quantity INT NOT NULL,
+     total_price DECIMAL(19, 2) NOT NULL,
+     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+     deleted BOOLEAN NOT NULL DEFAULT FALSE,
+     INDEX idx_order_items_order_id (order_id),
+     INDEX idx_order_items_product_id (product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+

--- a/src/test/java/com/example/minimart/order/repository/entity/OrderItemTest.java
+++ b/src/test/java/com/example/minimart/order/repository/entity/OrderItemTest.java
@@ -14,6 +14,7 @@ class OrderItemTest {
     @DisplayName("유효한 값으로 OrderItem 생성 성공")
     void createOrderItemWithValidData() {
         // given
+        Long orderId = 1L;
         Long productId = 1L;
         String productName = "Product A";
         String productOption = "Option A";
@@ -21,7 +22,7 @@ class OrderItemTest {
         int quantity = 3;
 
         // when
-        OrderItem orderItem = new OrderItem(productId, productName, productOption, unitPrice, quantity);
+        OrderItem orderItem = new OrderItem(orderId, productId, productName, productOption, unitPrice, quantity);
 
         // then
         assertEquals(BigDecimal.valueOf(301.50), orderItem.getTotalPrice());
@@ -32,6 +33,7 @@ class OrderItemTest {
     @DisplayName("unitPrice가 null일 경우 IllegalArgumentException 발생")
     void createOrderItemWithNullUnitPrice() {
         // given
+        Long orderId = 1L;
         Long productId = 1L;
         String productName = "Product A";
         String productOption = "Option A";
@@ -40,13 +42,14 @@ class OrderItemTest {
 
         // when
         // then
-        assertThrows(IllegalArgumentException.class, () -> new OrderItem(productId, productName, productOption, unitPrice, quantity));
+        assertThrows(IllegalArgumentException.class, () -> new OrderItem(orderId, productId, productName, productOption, unitPrice, quantity));
     }
 
     @Test
     @DisplayName("quantity가 0이거나 음수일 경우 IllegalArgumentException 발생")
     void createOrderItemWithInvalidQuantity() {
         // given
+        Long orderId = 1L;
         Long productId = 1L;
         String productName = "Product A";
         String productOption = "Option A";
@@ -54,15 +57,15 @@ class OrderItemTest {
 
         // when
         // then
-        assertThrows(IllegalArgumentException.class, () -> new OrderItem(productId, productName, productOption, unitPrice, 0));
-        assertThrows(IllegalArgumentException.class, () -> new OrderItem(productId, productName, productOption, unitPrice, -1));
+        assertThrows(IllegalArgumentException.class, () -> new OrderItem(orderId, productId, productName, productOption, unitPrice, 0));
+        assertThrows(IllegalArgumentException.class, () -> new OrderItem(orderId, productId, productName, productOption, unitPrice, -1));
     }
 
     @Test
     @DisplayName("calculateTotalPrice 메서드가 정확한 값을 반환")
     void calculateTotalPriceReturnsCorrectValue() {
         // given
-        OrderItem orderItem = new OrderItem(1L, "Product A", "Option A", BigDecimal.valueOf(99.99), 5);
+        OrderItem orderItem = new OrderItem(1L, 1L, "Product A", "Option A", BigDecimal.valueOf(99.99), 5);
 
         // when
         BigDecimal totalPrice = orderItem.calculateTotalPrice();
@@ -75,7 +78,7 @@ class OrderItemTest {
     @DisplayName("assignToOrder 메서드를 사용하여 유효한 orderId를 설정")
     void assignToOrderWithValidOrderId() {
         // given
-        OrderItem orderItem = new OrderItem(1L, "Product A", "Option A", BigDecimal.TEN, 2);
+        OrderItem orderItem = new OrderItem(1L, 1L, "Product A", "Option A", BigDecimal.TEN, 2);
         Long orderId = 123L;
 
         // when
@@ -89,7 +92,7 @@ class OrderItemTest {
     @DisplayName("assignToOrder 메서드 호출 시 orderId가 null이면 IllegalArgumentException 발생")
     void assignToOrderWithNullOrderIdThrowsException() {
         // given
-        OrderItem orderItem = new OrderItem(1L, "Product A", "Option A", BigDecimal.TEN, 2);
+        OrderItem orderItem = new OrderItem(1L, 1L, "Product A", "Option A", BigDecimal.TEN, 2);
 
         // when
         // then
@@ -100,7 +103,7 @@ class OrderItemTest {
     @DisplayName("assignToOrder 메서드로 이미 설정된 orderId를 재설정")
     void reassignToOrderWithNewOrderId() {
         // given
-        OrderItem orderItem = new OrderItem(1L, "Product A", "Option A", BigDecimal.TEN, 2);
+        OrderItem orderItem = new OrderItem(1L, 1L, "Product A", "Option A", BigDecimal.TEN, 2);
         Long initialOrderId = 123L;
         Long newOrderId = 456L;
 

--- a/src/test/java/com/example/minimart/order/repository/entity/OrderTest.java
+++ b/src/test/java/com/example/minimart/order/repository/entity/OrderTest.java
@@ -4,67 +4,29 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OrderTest {
 
     @Test
-    @DisplayName("null 리스트를 추가하려고 할 때 IllegalArgumentException 예외 발생")
-    void addItemsWithNullList() {
-        // given
-        // when
-        // then
-        assertThrows(IllegalArgumentException.class, () -> new Order(1L, BigDecimal.TEN, OrderStatus.PENDING, null));
-    }
-
-    @Test
-    @DisplayName("주문 항목이 비어 있는 경우 IllegalArgumentException 예외 발생")
-    void orderWithEmptyItemsThrowsException() {
-        // given
-        // when
-        // then
-        assertThrows(IllegalArgumentException.class, () -> new Order(1L, BigDecimal.TEN, OrderStatus.PENDING, List.of()));
-    }
-
-    @Test
-    @DisplayName("OrderItem에 orderId를 수동으로 설정하여 관계를 확인")
-    void setOrderIdManuallyInOrderItem() {
-        // given
-        OrderItem item1 = new OrderItem(1L, "Product A", "Option A", BigDecimal.TEN, 2);
-        List<OrderItem> items = List.of(item1);
-        Long orderId = 123L;
-
-        // when
-        Order order = new Order(1L, BigDecimal.TEN, OrderStatus.PENDING, items);
-        order.assignOrderIdToItems(orderId, items);
-
-        // then
-        assertEquals(orderId, item1.getOrderId());
-    }
-
-    @Test
     @DisplayName("총 가격이 음수인 경우 IllegalArgumentException 예외 발생")
     void orderWithNegativeTotalPriceThrowsException() {
         // given
-        List<OrderItem> items = List.of(new OrderItem(1L, "Product A", "Option A", BigDecimal.TEN, 1));
 
         // when
         // then
-        assertThrows(IllegalArgumentException.class, () -> new Order(1L, BigDecimal.valueOf(-10), OrderStatus.PENDING, items));
+        assertThrows(IllegalArgumentException.class, () -> new Order(1L, BigDecimal.valueOf(-10), OrderStatus.PENDING));
     }
 
     @Test
     @DisplayName("주문 상태가 null인 경우 IllegalArgumentException 예외 발생")
     void orderWithNullStatusThrowsException() {
         // given
-        List<OrderItem> items = List.of(new OrderItem(1L, "Product A", "Option A", BigDecimal.TEN, 1));
 
         // when
         // then
-        assertThrows(IllegalArgumentException.class, () -> new Order(1L, BigDecimal.TEN, null, items));
+        assertThrows(IllegalArgumentException.class, () -> new Order(1L, BigDecimal.TEN, null));
     }
 
 }

--- a/src/test/java/com/example/minimart/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/minimart/order/service/OrderServiceTest.java
@@ -1,0 +1,133 @@
+package com.example.minimart.order.service;
+
+import com.example.minimart.order.controller.dto.request.CreateOrderItemRequest;
+import com.example.minimart.order.controller.dto.request.CreateOrderRequest;
+import com.example.minimart.order.repository.OrderItemJpaRepository;
+import com.example.minimart.order.repository.OrderJpaRepository;
+import com.example.minimart.order.repository.entity.Order;
+import com.example.minimart.order.repository.entity.OrderStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderJpaRepository orderJpaRepository;
+
+    @Mock
+    private OrderItemJpaRepository orderItemJpaRepository;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Test
+    @DisplayName("주문 ID로 주문을 조회할 때, 주문이 없으면 IllegalArgumentException 예외 발생")
+    void getOrderThrowsExceptionIfOrderNotFound() {
+        // given
+        Long orderId = 1L;
+        when(orderJpaRepository.findById(orderId)).thenReturn(Optional.empty());
+
+        // when
+        // then
+        assertThrows(IllegalArgumentException.class, () -> orderService.getOrder(orderId));
+        verify(orderJpaRepository, times(1)).findById(orderId);
+    }
+
+    @Test
+    @DisplayName("주문 ID로 주문을 조회할 때, 주문이 있으면 해당 주문 반환")
+    void getOrderReturnsOrderIfExists() {
+        // given
+        Long orderId = 1L;
+        Order expectedOrder = new Order(1L, BigDecimal.valueOf(100), OrderStatus.PENDING);
+        when(orderJpaRepository.findById(orderId)).thenReturn(Optional.of(expectedOrder));
+
+        // when
+        Order order = orderService.getOrder(orderId);
+
+        // then
+        assertEquals(expectedOrder, order);
+        verify(orderJpaRepository, times(1)).findById(orderId);
+    }
+
+    @Test
+    @DisplayName("주문 생성 시 총 가격이 음수면 IllegalArgumentException 예외 발생")
+    void createOrderThrowsExceptionIfTotalPriceIsNegative() {
+        // given
+        CreateOrderRequest request = new CreateOrderRequest(
+            1L,
+            BigDecimal.valueOf(-100),
+            Collections.emptyList()
+        );
+
+        // when
+        // then
+        assertThrows(IllegalArgumentException.class, () -> orderService.createOrder(request));
+        verify(orderJpaRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("주문 생성 시 정상적인 요청일 경우 주문 저장 성공")
+    void createOrderSavesOrderIfRequestIsValid() {
+        // given
+        List<CreateOrderItemRequest> orderItems = List.of(
+            new CreateOrderItemRequest(1L, "Product A", 1, BigDecimal.TEN, "Option A")
+        );
+        CreateOrderRequest request = new CreateOrderRequest(1L, BigDecimal.valueOf(100), orderItems);
+
+        Order mockSavedOrder = new Order(1L, BigDecimal.valueOf(100), OrderStatus.PENDING);
+        when(orderJpaRepository.save(any(Order.class))).thenReturn(mockSavedOrder);
+
+        // when
+        orderService.createOrder(request);
+
+        // then
+        verify(orderJpaRepository, times(1)).save(any(Order.class));
+        verify(orderItemJpaRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("주문 목록 조회 시 빈 목록 반환")
+    void listOrdersReturnsEmptyListIfNoOrdersExist() {
+        // given
+        when(orderJpaRepository.findAll()).thenReturn(Collections.emptyList());
+
+        // when
+        List<Order> orders = orderService.listOrders();
+
+        // then
+        assertTrue(orders.isEmpty());
+        verify(orderJpaRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("주문 목록 조회 시 모든 주문 반환")
+    void listOrdersReturnsAllOrders() {
+        // given
+        List<Order> expectedOrders = List.of(
+            new Order(1L, BigDecimal.valueOf(100), OrderStatus.PENDING),
+            new Order(2L, BigDecimal.valueOf(200), OrderStatus.CONFIRMED)
+        );
+        when(orderJpaRepository.findAll()).thenReturn(expectedOrders);
+
+        // when
+        List<Order> actualOrders = orderService.listOrders();
+
+        // then
+        assertEquals(expectedOrders, actualOrders);
+        verify(orderJpaRepository, times(1)).findAll();
+    }
+
+}


### PR DESCRIPTION
### **작업 내용**

Spring Boot 환경에서 기존 Spring Framework 환경의 주문 서비스 및 컨트롤러 계층을 이전하였습니다.

---

### **주요 변경 사항**

1. **서비스 계층 추가**
   - `OrderService`
     - 주문 생성: `createOrder(CreateOrderRequest request)`
     - 주문 조회: `getOrder(Long id)`
     - 주문 목록 조회: `listOrders()`
   - **테스트 클래스**
     - `OrderServiceTest`
       - 테스트 케이스 작성

2. **컨트롤러 계층 추가**
   - `OrderController`
     - **POST** `/orders`: 주문 생성
     - **GET** `/orders/{id}`: 주문 조회
     - **GET** `/orders`: 주문 목록 조회

3. **DTO 클래스 분리**
   - `CreateOrderRequest`
   - `CreateOrderItemRequest`
   - DTO에 OpenAPI 애너테이션 추가
     - `@Schema`를 활용한 필드 설명 및 예제 설정

4. **schema.sql** 파일 작성
  - `orders`, `order_items` DDL 작성
  - `OrderItem` 클래스에 `create_at`, `update_at` 필드 추가

5. **application.yml** 내용 작성
  - JPA 및 DB 설정 내용 추가

---

### **테스트 수행 결과**

- **모든 테스트 성공**
  - `OrderServiceTest`
    - 주문 생성, 조회, 목록 조회 테스트 성공
    - 엣지 케이스 검증 통과
  - `Swagger UI` 확인
    - 경로 : `/swagger-ui/index.html`
    - SpringDoc OpenAPI를 통해 명세 확인 및 예제 값 실행을 통한 동작 확인 완료
